### PR TITLE
Bastion restructuring: targets

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,120 +1,19 @@
 ---
-- name: gather user data
-  getent:
-    database: passwd
-
-# tasks file for ovhbastion
-- name: include distribution family variables
-  include_vars: '{{ item }}'
-  with_first_found:
-    - '{{ ansible_facts.os_family }}.yml'
-    - '{{ ansible_facts.distribution }}.yml'
-
-- name: install python2 pip
-  package:
-    update_cache: yes
-    name:
-      - python-pip
-      - python-setuptools
-  when: ansible_facts['python_version'] is version('3', '<=')
-  tags:
-    - bastion_setup
-
-- name: install python3 pip
-  package:
-    update_cache: yes
-    name:
-      - python3-pip
-  when: ansible_facts['python_version'] is version('3', '>=')
-  tags:
-    - bastion_setup
-
-- name: install pexpect
-  pip:
-    name: pexpect
-  tags:
-    - bastion_setup
-
-- name: include distribution-specific tasks
-  include_tasks: '{{ item }}'
-  with_first_found:
-    - '{{ ansible_facts.os_family }}.yml'
-    - '{{ ansible_facts.distribution }}.yml'
-
-- name: create directory for bastion install
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: root
-    group: root
-    mode: "0775"
-  loop:
-    - "{{ bastion_install_dir }}"
-  tags:
-    - bastion_setup
-
-- name: extract bastion files to install directory
-  unarchive:
-    src: "{{ bastion_package_url }}"
-    dest: "{{ bastion_install_dir }}"
-    remote_src: yes
-    mode: "0775"
-    extra_opts:
-      - --strip-components=1
-  tags:
-    - bastion_setup
-
-- name: install bastion packages
-  shell:
-    cmd: "{{ bastion_install_dir }}/bin/admin/packages-check.sh -i -s -t >> .package-install-log"
-    chdir: "{{ bastion_install_dir }}"
-    creates: .package-install-log
-  tags:
-    - bastion_setup
-
-- name: complete basic system configuration
-  shell:
-    cmd: "{{ bastion_install_dir }}/bin/admin/install --new-install --no-wait >> .config-log"
-    chdir: "{{ bastion_install_dir }}"
-    creates: .config-log
-  tags:
-    - bastion_setup
-
-- name: verify perl module installation
-  shell:
-    cmd: "{{ bastion_install_dir }}/bin/dev/perl-check.sh >> .perlcheck-log"
-    chdir: "{{ bastion_install_dir }}"
-    creates: .perlcheck-log
-  tags:
-    - bastion_setup
-
-- name: replace default configuration file
-  template:
-    src: bastion_conf.j2
-    dest: /etc/bastion/bastion.conf
-    owner: root
-    group: root
-    mode: '0644'
-  tags:
-    - bastion_setup
-
-- name: complete initial account setup
-  expect:
-    command: "{{ bastion_install_dir }}/bin/admin/setup-first-admin-account.sh {{ bastion_superadmin_uname }} auto"
-    responses:
-      (?i)passphrase: "{{ ssh_key }}"
-    chdir: "{{ bastion_install_dir }}"
+- name: run bastion setup tasks
+  include_tasks: setup.yml
   when:
-    - bastion_create_admin | bool
-    - bastion_superadmin_uname not in getent_passwd.keys()
-  no_log: true
-  tags:
-    - bastion_setup
-
-- name: restart sshd to apply changes
-  service:
-    name: sshd
-    state: restarted
+    - bastion_node_role is defined
+    - bastion_node_role == "bastion"
 
 - name: run user bootstrap tasks
   include_tasks: users.yml
+  when:
+    - bastion_node_role is defined
+    - bastion_node_role == "bastion"
+
+- name: run target bootstrap tasks
+  include_tasks: targets.yml
+  when:
+    - bastion_node_role is defined
+    - bastion_node_role == "target"
+

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,0 +1,117 @@
+---
+- name: gather user data
+  getent:
+    database: passwd
+
+# tasks file for ovhbastion
+- name: include distribution family variables
+  include_vars: '{{ item }}'
+  with_first_found:
+    - '{{ ansible_facts.os_family }}.yml'
+    - '{{ ansible_facts.distribution }}.yml'
+
+- name: install python2 pip
+  package:
+    update_cache: yes
+    name:
+      - python-pip
+      - python-setuptools
+  when: ansible_facts['python_version'] is version('3', '<=')
+  tags:
+    - bastion_setup
+
+- name: install python3 pip
+  package:
+    update_cache: yes
+    name:
+      - python3-pip
+  when: ansible_facts['python_version'] is version('3', '>=')
+  tags:
+    - bastion_setup
+
+- name: install pexpect
+  pip:
+    name: pexpect
+  tags:
+    - bastion_setup
+
+- name: include distribution-specific tasks
+  include_tasks: '{{ item }}'
+  with_first_found:
+    - '{{ ansible_facts.os_family }}.yml'
+    - '{{ ansible_facts.distribution }}.yml'
+
+- name: create directory for bastion install
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0775"
+  loop:
+    - "{{ bastion_install_dir }}"
+  tags:
+    - bastion_setup
+
+- name: extract bastion files to install directory
+  unarchive:
+    src: "{{ bastion_package_url }}"
+    dest: "{{ bastion_install_dir }}"
+    remote_src: yes
+    mode: "0775"
+    extra_opts:
+      - --strip-components=1
+  tags:
+    - bastion_setup
+
+- name: install bastion packages
+  shell:
+    cmd: "{{ bastion_install_dir }}/bin/admin/packages-check.sh -i -s -t >> .package-install-log"
+    chdir: "{{ bastion_install_dir }}"
+    creates: .package-install-log
+  tags:
+    - bastion_setup
+
+- name: complete basic system configuration
+  shell:
+    cmd: "{{ bastion_install_dir }}/bin/admin/install --new-install --no-wait >> .config-log"
+    chdir: "{{ bastion_install_dir }}"
+    creates: .config-log
+  tags:
+    - bastion_setup
+
+- name: verify perl module installation
+  shell:
+    cmd: "{{ bastion_install_dir }}/bin/dev/perl-check.sh >> .perlcheck-log"
+    chdir: "{{ bastion_install_dir }}"
+    creates: .perlcheck-log
+  tags:
+    - bastion_setup
+
+- name: replace default configuration file
+  template:
+    src: bastion_conf.j2
+    dest: /etc/bastion/bastion.conf
+    owner: root
+    group: root
+    mode: '0644'
+  tags:
+    - bastion_setup
+
+- name: complete initial account setup
+  expect:
+    command: "{{ bastion_install_dir }}/bin/admin/setup-first-admin-account.sh {{ bastion_superadmin_uname }} auto"
+    responses:
+      (?i)passphrase: "{{ ssh_key }}"
+    chdir: "{{ bastion_install_dir }}"
+  when:
+    - bastion_create_admin | bool
+    - bastion_superadmin_uname not in getent_passwd.keys()
+  no_log: true
+  tags:
+    - bastion_setup
+
+- name: restart sshd to apply changes
+  service:
+    name: sshd
+    state: restarted

--- a/tasks/targets.yml
+++ b/tasks/targets.yml
@@ -1,0 +1,14 @@
+---
+# user_key_map is a mapping of bastion user to public egress key
+#
+# bastion_target_groups is a map of node users to a list of authorized bastion users
+#
+# So we need to go role by role, then by authorized user, and get its pubkey
+# from the placeholder facts
+- name: install bastion egress key on target role users
+  authorized_key:
+    user: "{{ item.0.key }}"
+    key: "{{ hostvars['bastion_fact_placeholder']['user_key_map'][item.1] }}"
+  with_subelements:
+    - "{{ bastion_target_groups | dict2items }}"
+    - value

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -31,7 +31,7 @@
     - "{{ bastion_initial_users }}"
     - groups
     - flags:
-        skip_missing: true
+      skip_missing: true
   tags:
     - bastion_users
   when: false
@@ -46,7 +46,7 @@
     - "{{ bastion_initial_users }}"
     - hosts
     - flags:
-        skip_missing: true
+      skip_missing: true
   tags:
     - bastion_users
 
@@ -59,7 +59,24 @@
     - "{{ bastion_initial_groups }}"
     - hosts
     - flags:
-        skip_missing: true
+      skip_missing: true
   tags:
     - bastion_users
   when: false
+
+- name: save egress keys from users
+  become: no
+  delegate_to: localhost
+  shell: "{{ bastion_ansible_ssh_command }} accountListEgressKeys --account {{ item.name }} --quiet | grep '^from='"
+  with_items: "{{ bastion_initial_users }}"
+  register: bastion_users_ssh_keys
+  tags:
+    - bastion_users
+
+- name: create placeholder host
+  add_host:
+    name: bastion_fact_placeholder
+    # this one is complicated: iterate over the list of users, pair them with
+    # their public key, and then turn the list of lists into a dict, with
+    # username as key, and public key as value
+    user_key_map: "{{ dict(bastion_initial_users | map(attribute='name') | zip(bastion_users_ssh_keys.results | map(attribute='stdout'))) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-bastion_ansible_ssh_command: "ssh {{ bastion_superadmin_uname }}@{{ inventory_hostname }} -p {{ ansible_port | default(22) }} -- --osh"
+bastion_ansible_ssh_command: "ssh -4 {{ bastion_superadmin_uname }}@{{ inventory_hostname }} -p {{ ansible_port | default(22) }} -- --osh"


### PR DESCRIPTION
This alters the structure of bastion tasks in order to allow separating the bastion itself from its targets. By doing this, we implement the installation of bastion egress keys on their targets.